### PR TITLE
Fix virtual env

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,9 +12,13 @@ ENV PYTHONPATH /srv
 ENV PYTHONUNBUFFERED 1
 
 #install uv
-RUN apt-get update
+RUN apt-get update && apt-get install -y postgresql-client
 RUN pip install --upgrade pip uv
 RUN python -m uv venv
+
+# activate virtual env
+ARG VIRTUAL_ENV=/usr/src/app/.venv
+ENV PATH=/usr/src/app/.venv/bin:$PATH
 
 # install dependencies
 COPY ./requirements.txt .


### PR DESCRIPTION
Nel tuo Dockerfile avevi solo creato il virtual_env ma non lo usavi mai e stavi installando i pacchetti nel contesto generale di Python. Per altro, in Docker, non e' indispensabile usare un virtual env, dato che hai il controllo totale sul file system.
Ad ogni modo, cosi' come l'ho confiugurato ora funziona.

Ma segnala un ulteriore errore, legato alla mancanza di alcune env vars:


```
08:29 $ podman run -it enrico 
Traceback (most recent call last):
  File "/usr/src/app/.venv/lib/python3.11/site-packages/environ/environ.py", line 388, in get_value
    value = self.ENVIRON[var_name]
            ~~~~~~~~~~~~^^^^^^^^^^
  File "<frozen os>", line 679, in __getitem__
KeyError: 'MAILGUN_API_KEY'

```